### PR TITLE
Update 5.5.16.sh

### DIFF
--- a/lang/php/5.5.16.sh
+++ b/lang/php/5.5.16.sh
@@ -136,8 +136,8 @@ vim /srv/php-5.5.16/etc/php.cli.ini <<EOF > /dev/null 2>&1
 :wq
 EOF
 
-cat >> ~/.bashrc <<EOF
+cat >> ~/.bashrc <<'EOF'
 
 alias php='php -c /srv/php/etc/php.cli.ini'
-PATH=$PATH:/srv/php/bin:
+PATH=$PATH:/srv/php/bin
 EOF


### PR DESCRIPTION
禁止 shell 解析 'PATH=$PATH:/srv/php/bin' 中的变量，并将工作目录从 PATH 中除去
